### PR TITLE
Refactor AIAPI gateway deployment flow

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIConstants.java
@@ -49,6 +49,7 @@ public class APIConstants {
 
     public static class AIAPIConstants {
         public static final String LLM_PROVIDERS = "llmProviders";
+        public static final String LLM_PROVIDER_ID = "llmProviderId";
         public static final String API_KEY_IDENTIFIER_TYPE_HEADER = "HEADER";
         public static final String API_KEY_IDENTIFIER_TYPE_QUERY_PARAMETER = "QUERY_PARAMETER";
         public static final String AI_API_REQUEST_METADATA = "AI_API_REQUEST_METADATA";

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/AiApiHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/AiApiHandler.java
@@ -52,6 +52,7 @@ import java.util.TreeMap;
 public class AiApiHandler extends AbstractHandler {
 
     private static final Log log = LogFactory.getLog(AiApiHandler.class);
+    private String llmProviderId;
 
     /**
      * Processes the request flow.
@@ -99,23 +100,11 @@ public class AiApiHandler extends AbstractHandler {
     private boolean processMessage(MessageContext messageContext, boolean isRequest) {
 
         try {
-
-            String path = ApiUtils.getFullRequestPath(messageContext);
-            String tenantDomain = GatewayUtils.getTenantDomain();
-            TreeMap<String, API> selectedAPIS = Utils.getSelectedAPIList(path, tenantDomain);
-            API selectedAPI = selectedAPIS.get(selectedAPIS.firstKey());
-            if (selectedAPI == null) {
-                log.error("No API found for path: " + path + " in tenant domain: " + tenantDomain);
+            if (this.llmProviderId == null) {
+                log.error("No LLM provider ID provided by TemplateBuilderUtil");
                 return true;
             }
-            AIConfiguration aiConfiguration = selectedAPI.getAiConfiguration();
-            if (aiConfiguration == null) {
-                log.debug("No AI configuration for API: " + selectedAPI.getApiId() + " in tenant domain: "
-                        + tenantDomain);
-                return true;
-            }
-            String llmProviderId = aiConfiguration.getLlmProviderId();
-            LLMProviderInfo provider = DataHolder.getInstance().getLLMProviderConfigurations(llmProviderId);
+            LLMProviderInfo provider = DataHolder.getInstance().getLLMProviderConfigurations(this.llmProviderId);
             if (provider == null) {
                 log.error("No LLM provider found for provider ID: " + llmProviderId);
                 return false;
@@ -271,5 +260,14 @@ public class AiApiHandler extends AbstractHandler {
                 ((Axis2MessageContext) messageContext).getAxis2MessageContext();
         return (Map<String, String>) axis2MessageContext
                 .getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
+    }
+
+    /**
+     * Sets the LLM provider ID.
+     *
+     * @param llmProviderId the LLM provider ID
+     */
+    public void setLlmProviderId(String llmProviderId) {
+        this.llmProviderId = llmProviderId;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/TemplateBuilderUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/TemplateBuilderUtil.java
@@ -32,6 +32,7 @@ import org.json.JSONException;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
+import org.wso2.carbon.apimgt.api.APIConstants.AIAPIConstants;
 import org.wso2.carbon.apimgt.api.APIDefinition;
 import org.wso2.carbon.apimgt.api.APIDefinitionValidationResponse;
 import org.wso2.carbon.apimgt.api.APIManagementException;
@@ -273,9 +274,17 @@ public class TemplateBuilderUtil {
                     Collections.emptyMap());
         }
 
-        vtb.addHandler(
-                "org.wso2.carbon.apimgt.gateway.handlers.AiApiHandler"
-                , Collections.emptyMap());
+        if (APIConstants.API_SUBTYPE_AI_API.equals(api.getSubtype())) {
+            Map<String, String> aiProperties = new HashMap<>();
+            try {
+                aiProperties.put(AIAPIConstants.LLM_PROVIDER_ID, api.getAiConfiguration().getLlmProviderId());
+                vtb.addHandler(
+                        "org.wso2.carbon.apimgt.gateway.handlers.AiApiHandler"
+                        , aiProperties);
+            } catch (Exception e) {
+                throw new APIManagementException(e);
+            }
+        }
 
         if (!APIUtil.isStreamingApi(api)) {
             Map<String, String> properties = new HashMap<String, String>();


### PR DESCRIPTION
## Purpose

The existing approach for handling AI APIs involves using the `tenantAPIMap` in `DataHolder` to retrieve the `llmProviderId` associated with a specific API. However, since the `tenantAPIMap` contains all types of APIs, filtering the relevant AI APIs at request time within the `AiApiHandler` introduces performance overhead.

This PR introduces an optimized solution that leverages the `TemplateBuilderUtil` to assign the `llmProviderId` to the `AiApiHandler` during API deployment. Additionally, the `AiApiHandler` is now attached exclusively to AI APIs, ensuring more efficient processing and reducing unnecessary filtering during request handling.
